### PR TITLE
Cause a patchouli book load on clients. Fixes #1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ loader_version=0.14.4
 fabric_version=0.51.1+1.18.2
 
 # Mod Properties
-mod_version = 0.0.2
+mod_version = 0.0.3
 maven_group = com.parzivail.blanketconpatches
 archives_base_name = blanketconpatches

--- a/src/main/java/com/parzivail/blanketconpatches/mixin/PlayerAdvancementTrackerMixin.java
+++ b/src/main/java/com/parzivail/blanketconpatches/mixin/PlayerAdvancementTrackerMixin.java
@@ -1,24 +1,41 @@
 package com.parzivail.blanketconpatches.mixin;
 
 import net.minecraft.advancement.PlayerAdvancementTracker;
+import net.minecraft.network.packet.s2c.play.AdvancementUpdateS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Collections;
 
 @Mixin(PlayerAdvancementTracker.class)
 public class PlayerAdvancementTrackerMixin
 {
 	@Shadow
 	private boolean dirty;
+	
+	@Unique private boolean sentFunnyPackets = false;
 
 	@Inject(method = "sendUpdate(Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("HEAD"), cancellable = true)
 	public void sendUpdate(ServerPlayerEntity serverPlayerEntity, CallbackInfo ci)
 	{
 		// Do not the cat
 		dirty = false;
+		
+		// At least once, send two advancement packets anyway, because Patchouli loads books clientside upon receiving the second advancement update packet.
+		// The packets don't actually have to contain any advancements.
+		// See https://github.com/parzivail/blanketcon-patches/issues/1
+		if (!sentFunnyPackets)
+		{
+			serverPlayerEntity.networkHandler.sendPacket(new AdvancementUpdateS2CPacket(false, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap()));
+			serverPlayerEntity.networkHandler.sendPacket(new AdvancementUpdateS2CPacket(false, Collections.emptyList(), Collections.emptySet(), Collections.emptyMap()));
+			sentFunnyPackets = true;
+		}
+		
 		ci.cancel();
 	}
 }


### PR DESCRIPTION
Sends two blank advancement packets instead of completely suppressing them. If the patchouli disableAdvancementLocking is enabled, this triggers the clientside book load and means you can browse through the book. Phew.